### PR TITLE
Make VANTAGE-Reactions and NESO-Particles features compile only if -…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,14 @@ endif()
 
 
 find_package(MPI REQUIRED)
-find_package(NESO-Particles REQUIRED)
-find_sycl_if_required()
-find_package(VANTAGE-Reactions REQUIRED)
+
+# option for whether or not to compile with VANTAGE-Reactions and NESO-Particles
+option(HERMES_USE_VANTAGE "Build Hermes with VANTAGE" OFF)
+if(HERMES_USE_VANTAGE)
+  find_package(NESO-Particles REQUIRED)
+  find_sycl_if_required()
+  find_package(VANTAGE-Reactions REQUIRED)
+endif()
 
 set(HERMES_SOURCES
     src/classical_diffusion.cxx
@@ -170,7 +175,16 @@ set(HERMES_SOURCES
 # Compile Hermes sources into a library, which can be used for unit tests
 add_library(hermes-3-lib ${HERMES_SOURCES})
 
-target_link_libraries(hermes-3-lib PUBLIC bout++::bout++ VANTAGE-Reactions::VANTAGE-Reactions)
+# logic for linking libraries with an optional VANTAGE-Reactions dependence
+if(HERMES_USE_VANTAGE)
+  # preprocessor flag for optional VANTAGE includes
+  add_definitions(-DHERMES_USE_VANTAGE)
+  # link bout++ and VANTAGE-Reactions libraries
+  target_link_libraries(hermes-3-lib PUBLIC bout++::bout++ VANTAGE-Reactions::VANTAGE-Reactions)
+else()
+  # link only to bout++
+  target_link_libraries(hermes-3-lib PUBLIC bout++::bout++)
+endif()
 
 target_compile_features(hermes-3-lib PUBLIC cxx_std_17)
 set_target_properties(hermes-3-lib PROPERTIES CXX_EXTENSIONS OFF)
@@ -183,14 +197,16 @@ target_include_directories(hermes-3-lib PUBLIC
 
 # Have hermes-3-lib look for dynamic libs in ./ before searching elsewhere
 set_target_properties(hermes-3-lib PROPERTIES BUILD_RPATH "$ORIGIN")
-add_sycl_to_target(TARGET hermes-3-lib SOURCES ${HERMES_SOURCES})
-
+if(HERMES_USE_VANTAGE)
+  add_sycl_to_target(TARGET hermes-3-lib SOURCES ${HERMES_SOURCES})
+endif()
 # The main executable target
 add_executable(hermes-3
                hermes-3.cxx
                ${CMAKE_CURRENT_BINARY_DIR}/include/revision.hxx)
-
-add_sycl_to_target(TARGET hermes-3 SOURCES hermes-3.cxx)
+if(HERMES_USE_VANTAGE)
+  add_sycl_to_target(TARGET hermes-3 SOURCES hermes-3.cxx)
+endif()
 target_link_libraries(hermes-3 PRIVATE hermes-3-lib)
 
 target_include_directories(hermes-3 PUBLIC
@@ -230,12 +246,14 @@ if(HERMES_COPY_TESTS_TO_BUILD)
                     ${CMAKE_SOURCE_DIR}/tests $<TARGET_FILE_DIR:${PROJECT_NAME}>/tests)
 endif()
 
-# Test of bout+neso
-add_executable(bout-particle-push
-               bout-particle-push.cxx
-               ${CMAKE_CURRENT_BINARY_DIR}/include/revision.hxx)
-add_sycl_to_target(TARGET bout-particle-push SOURCES bout-particle-push.cxx)
-target_link_libraries(bout-particle-push PUBLIC bout++::bout++ VANTAGE-Reactions::VANTAGE-Reactions)
+if(HERMES_USE_VANTAGE)
+  # Test of bout+neso
+  add_executable(bout-particle-push
+                bout-particle-push.cxx
+                ${CMAKE_CURRENT_BINARY_DIR}/include/revision.hxx)
+  add_sycl_to_target(TARGET bout-particle-push SOURCES bout-particle-push.cxx)
+  target_link_libraries(bout-particle-push PUBLIC bout++::bout++ VANTAGE-Reactions::VANTAGE-Reactions)
+endif()
 
 # Tests
 option(HERMES_TESTS "Build the tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,15 +175,14 @@ set(HERMES_SOURCES
 # Compile Hermes sources into a library, which can be used for unit tests
 add_library(hermes-3-lib ${HERMES_SOURCES})
 
+# link to bout++
+target_link_libraries(hermes-3-lib PUBLIC bout++::bout++)
 # logic for linking libraries with an optional VANTAGE-Reactions dependence
 if(HERMES_USE_VANTAGE)
   # preprocessor flag for optional VANTAGE includes
-  add_definitions(-DHERMES_USE_VANTAGE)
-  # link bout++ and VANTAGE-Reactions libraries
-  target_link_libraries(hermes-3-lib PUBLIC bout++::bout++ VANTAGE-Reactions::VANTAGE-Reactions)
-else()
-  # link only to bout++
-  target_link_libraries(hermes-3-lib PUBLIC bout++::bout++)
+  target_compile_definitions(hermes-3-lib PUBLIC HERMES_INCLUDE_VANTAGE)
+  # link to VANTAGE-Reactions libraries
+  target_link_libraries(hermes-3-lib PUBLIC VANTAGE-Reactions::VANTAGE-Reactions)
 endif()
 
 target_compile_features(hermes-3-lib PUBLIC cxx_std_17)

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -84,9 +84,9 @@
 #include <bout/field_factory.hxx>
 
 #include "include/recalculate_metric.hxx"
-
+#ifdef HERMES_USE_VANTAGE
 #include "include/particle_pusher_include.hxx"
-
+#endif
 #if !BOUT_USE_METRIC_3D
 // For standard 2D metrics,
 // Hermes operators don't need parallel slices

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -84,7 +84,7 @@
 #include <bout/field_factory.hxx>
 
 #include "include/recalculate_metric.hxx"
-#ifdef HERMES_USE_VANTAGE
+#ifdef HERMES_INCLUDE_VANTAGE
 #include "include/particle_pusher_include.hxx"
 #endif
 #if !BOUT_USE_METRIC_3D


### PR DESCRIPTION
…DHERMES_USE_VANTAGE=ON is passed to to CMake, i.e., if the configuration command is as follows. `$ in_h3env cmake . -B path/to/build -DBOUT_USE_PETSC=ON -DHERMES_USE_VANTAGE=ON`.