### PR TITLE
Integrate VANTAGE-Reactions

### DIFF
--- a/bout-particle-push.cxx
+++ b/bout-particle-push.cxx
@@ -13,10 +13,15 @@
 #include <petscviewerhdf5.h>
 #include <string>
 #include <vector>
+// for reactions integration
+#include <reactions/reactions.hpp>
 
 #ifndef NESO_PARTICLES_PETSC
 static_assert(false, "NESO-Particles was installed without PETSc support.");
 #else
+
+using namespace NESO::Particles;
+using namespace VANTAGE::Reactions;
 
 template <typename T, typename U>
 inline void ASSERT_EQ(T t, U u) {
@@ -186,8 +191,6 @@ std::vector<PetscInt> cells_definition_from_RZ_ivertex(
   }
   return cells;
 }
-
-using namespace NESO::Particles;
 
 int main(int argc, char** argv) {
   // initialise_mpi(&argc, &argv);
@@ -526,6 +529,10 @@ int main(int argc, char** argv) {
         std::make_shared<PetscInterface::DMPlexLocalMapper>(sycl_target, neso_mesh);
     // Create a domain from the neso_mesh and the mapper.
     auto domain = std::make_shared<Domain>(neso_mesh, mapper);
+
+    auto electron_species = Species("ELECTRON");
+    auto main_species = Species("ION", 1.0, 0.0, 0);
+    std::vector<Species> fluid_species = {electron_species, main_species};
 
     // Create the particle properties (note that if you are using the Reactions
     // project it has its owne particle spec builder).

--- a/bout-particle-push.cxx
+++ b/bout-particle-push.cxx
@@ -761,6 +761,13 @@ int main(int argc, char** argv) {
     //   }
     //   output << "\n";
     // }
+    // Options object to use to write out diagnostic data of fluid quantities
+    Options bout_output_data;
+    bout_output_data["neutral_density"] = density;
+    // Set the time attribute
+    bout_output_data["neutral_density"].attributes["time_dimension"] = "t";
+    std::string particle_data_filename = fmt::format("bout_particle_moments_{}.nc",mpi_rank);
+    bout::OptionsIO::create(particle_data_filename)->write(bout_output_data);
 
     for (int stepx = 0; stepx < nsteps; stepx++) {
       // nprint("step:", stepx);
@@ -774,6 +781,10 @@ int main(int argc, char** argv) {
       h5part.write();
       // uncomment to print particle info
       // A_particle_group->print(Sym<REAL>("POSITION"), Sym<INT>("ID"), Sym<REAL>("WEIGHT"));
+      // update density and write
+      bout_output_data["neutral_density"] = density;
+      // Append data to file
+      bout::OptionsIO::create({{"file", particle_data_filename}, {"append", true}})->write(bout_output_data);
     }
 
     // uncomment to write a trajectory

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -30,12 +30,12 @@ Zxy_lower_right_corners = y - 0.5*dy
 Zxy_upper_left_corners = y + 0.5*dy
 Zxy_upper_right_corners = y + 0.5*dy
 
-particle_weights = 1.0
+initial_density = 1.0
 
 [neso_particles]
 npart_per_cell = 1
 dt = 0.005
-nsteps = 50
+nsteps = 1
 
 [VANTAGE_reactions]
 remove_threshold = 1.0e-10

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -38,6 +38,6 @@ dt = 0.005
 nsteps = 1
 
 [VANTAGE_reactions]
-remove_threshold = 1.0e-10
-merge_threshold = 1.0e-2
+remove_threshold = 0.0e-10
+merge_threshold = 0.0e-2
 iz_rate = 0.0

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -30,11 +30,14 @@ Zxy_lower_right_corners = y - 0.5*dy
 Zxy_upper_left_corners = y + 0.5*dy
 Zxy_upper_right_corners = y + 0.5*dy
 
-phi = 0
-ex = 0
-ey = 0
-[neso_particles]
+particle_weights = 1.0
 
+[neso_particles]
 npart_per_cell = 1
 dt = 0.005
 nsteps = 50
+
+[VANTAGE_reactions]
+remove_threshold = 1.0e-10
+merge_threshold = 1.0e-2
+iz_rate = 0.0

--- a/scripts/dmplex_tools_for_particle_pusher/particle_animator.py
+++ b/scripts/dmplex_tools_for_particle_pusher/particle_animator.py
@@ -54,8 +54,8 @@ def load_particle_data(file_path):
     for it in range(0,nstep):
         group = particle_data[f"Step#{it}"]
         #print(list(group.keys()))
-        P_0 = group["P_0"]
-        P_1 = group["P_1"]
+        P_0 = group["POSITION_0"]
+        P_1 = group["POSITION_1"]
         nparticles = len(P_0)
         pdata = np.zeros((nparticles,2))
         pdata[:,0] = P_0


### PR DESCRIPTION
Several improvements:
 - Separate DMPlex creation into a function.
 - Introduce a BOUT++ diagnostic of Field2D density.
 - Create a particle specification consistent with VANTAGE-Reactions.
 - Upgrade the particle pusher to use features for ionisation from VANTAGE-Reactions, with current functionality able to reduce the particle weight until the particles are removed or merged at the thresholds controlled by `remove_threshold` and `merge_threshold`. 
 - Updates to the example input file at `examples/particle-push-slab/BOUT.inp`.

Note that the `bout-particle-push` program remains a work in progress.