### PR TITLE
Integrate VANTAGE-Reactions: mass conservation checks of ionisation reactions

### DIFF
--- a/bout-particle-push.cxx
+++ b/bout-particle-push.cxx
@@ -197,306 +197,311 @@ std::vector<PetscInt> cells_definition_from_RZ_ivertex(
   return cells;
 }
 
-DM create_dmplex_from_Bout_mesh(Mesh* bout_mesh, std::shared_ptr<SYCLTarget> sycl_target){
-    bool use_cxx_ivertex = Options::root()["mesh"]["use_cxx_ivertex"].withDefault(false);
-    std::string dmplex_name =
-        Options::root()["mesh"]["dmplex_name"].withDefault("hypnotoad_dmplex_mesh");
-    std::string dmplex_h5_filename =
-        Options::root()["mesh"]["dmplex_h5_filename"].withDefault(
-            "hypnotoad_dmplex_mesh_output.h5");
-    output << fmt::format("Using option use_cxx_ivertex = {}", use_cxx_ivertex)
-          << std::endl;
-    bout_mesh->load();
-    Field2D Rxy_lower_left_corners;
-    Field2D Rxy_lower_right_corners;
-    Field2D Rxy_upper_right_corners;
-    Field2D Rxy_upper_left_corners;
-    Field2D Zxy_lower_left_corners;
-    Field2D Zxy_lower_right_corners;
-    Field2D Zxy_upper_right_corners;
-    Field2D Zxy_upper_left_corners;
-    // mesh->get(ivertex, "ivertex_lower_left_corners");
-    bout_mesh->get(Rxy_lower_left_corners, "Rxy_corners");
-    bout_mesh->get(Rxy_lower_right_corners, "Rxy_lower_right_corners");
-    bout_mesh->get(Rxy_upper_right_corners, "Rxy_upper_right_corners");
-    bout_mesh->get(Rxy_upper_left_corners, "Rxy_upper_left_corners");
-    bout_mesh->get(Zxy_lower_left_corners, "Zxy_corners");
-    bout_mesh->get(Zxy_lower_right_corners, "Zxy_lower_right_corners");
-    bout_mesh->get(Zxy_upper_right_corners, "Zxy_upper_right_corners");
-    bout_mesh->get(Zxy_upper_left_corners, "Zxy_upper_left_corners");
-    Field2D ivertex_lower_left_corners;
-    Field2D ivertex_lower_right_corners;
-    Field2D ivertex_upper_right_corners;
-    Field2D ivertex_upper_left_corners;
-    if (!use_cxx_ivertex) {
-      bout_mesh->get(ivertex_lower_left_corners, "ivertex_lower_left_corners");
-      bout_mesh->get(ivertex_lower_right_corners, "ivertex_lower_right_corners");
-      bout_mesh->get(ivertex_upper_right_corners, "ivertex_upper_right_corners");
-      bout_mesh->get(ivertex_upper_left_corners, "ivertex_upper_left_corners");
-    }
-    // local number of x cells, excluding guards
-    int Nx = bout_mesh->xend - bout_mesh->xstart + 1;
-    // local number of y cells, excluding guards
-    int Ny = bout_mesh->yend - bout_mesh->ystart + 1;
-    // output << "Nx " + std::to_string(Nx) + "Ny " + std::to_string(Ny) << "\n";
-    // output << "Got here -1 \n";
+DM create_dmplex_from_Bout_mesh(Mesh* bout_mesh,
+                                std::shared_ptr<SYCLTarget> sycl_target) {
+  bool use_cxx_ivertex = Options::root()["mesh"]["use_cxx_ivertex"].withDefault(false);
+  std::string dmplex_name =
+      Options::root()["mesh"]["dmplex_name"].withDefault("hypnotoad_dmplex_mesh");
+  std::string dmplex_h5_filename =
+      Options::root()["mesh"]["dmplex_h5_filename"].withDefault(
+          "hypnotoad_dmplex_mesh_output.h5");
+  output << fmt::format("Using option use_cxx_ivertex = {}", use_cxx_ivertex)
+         << std::endl;
+  bout_mesh->load();
+  Field2D Rxy_lower_left_corners;
+  Field2D Rxy_lower_right_corners;
+  Field2D Rxy_upper_right_corners;
+  Field2D Rxy_upper_left_corners;
+  Field2D Zxy_lower_left_corners;
+  Field2D Zxy_lower_right_corners;
+  Field2D Zxy_upper_right_corners;
+  Field2D Zxy_upper_left_corners;
+  // mesh->get(ivertex, "ivertex_lower_left_corners");
+  bout_mesh->get(Rxy_lower_left_corners, "Rxy_corners");
+  bout_mesh->get(Rxy_lower_right_corners, "Rxy_lower_right_corners");
+  bout_mesh->get(Rxy_upper_right_corners, "Rxy_upper_right_corners");
+  bout_mesh->get(Rxy_upper_left_corners, "Rxy_upper_left_corners");
+  bout_mesh->get(Zxy_lower_left_corners, "Zxy_corners");
+  bout_mesh->get(Zxy_lower_right_corners, "Zxy_lower_right_corners");
+  bout_mesh->get(Zxy_upper_right_corners, "Zxy_upper_right_corners");
+  bout_mesh->get(Zxy_upper_left_corners, "Zxy_upper_left_corners");
+  Field2D ivertex_lower_left_corners;
+  Field2D ivertex_lower_right_corners;
+  Field2D ivertex_upper_right_corners;
+  Field2D ivertex_upper_left_corners;
+  if (!use_cxx_ivertex) {
+    bout_mesh->get(ivertex_lower_left_corners, "ivertex_lower_left_corners");
+    bout_mesh->get(ivertex_lower_right_corners, "ivertex_lower_right_corners");
+    bout_mesh->get(ivertex_upper_right_corners, "ivertex_upper_right_corners");
+    bout_mesh->get(ivertex_upper_left_corners, "ivertex_upper_left_corners");
+  }
+  // local number of x cells, excluding guards
+  int Nx = bout_mesh->xend - bout_mesh->xstart + 1;
+  // local number of y cells, excluding guards
+  int Ny = bout_mesh->yend - bout_mesh->ystart + 1;
+  // output << "Nx " + std::to_string(Nx) + "Ny " + std::to_string(Ny) << "\n";
+  // output << "Got here -1 \n";
 
-    // PETSCCHK(PetscInitializeNoArguments());
-    // auto sycl_target = std::make_shared<SYCLTarget>(0, PETSC_COMM_WORLD);
-    const int mpi_size = sycl_target->comm_pair.size_parent;
-    const int mpi_rank = sycl_target->comm_pair.rank_parent;
-    // output << "Got here 0 \n";
-    // global number of physical nonunique vertices stored in hypnotoad datasets
-    const int N_nonunique_vertices = mpi_size * Nx * Ny;
-    // arrays to fill with local data
-    std::vector<double> local_Z_lower_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_R_lower_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_Z_lower_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_R_lower_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_Z_upper_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_R_upper_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_Z_upper_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> local_R_upper_left_vertices(N_nonunique_vertices, 0.0);
-    // arrays to receive the summed data across ranks
-    std::vector<double> global_Z_lower_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_R_lower_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_Z_lower_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_R_lower_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_Z_upper_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_R_upper_right_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_Z_upper_left_vertices(N_nonunique_vertices, 0.0);
-    std::vector<double> global_R_upper_left_vertices(N_nonunique_vertices, 0.0);
-    // fill these vectors with vertex values from the local rank
-    // at indices determined by the local rank
-    int icxy = Nx * Ny * mpi_rank;
-    for (int ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
-      for (int iy = bout_mesh->ystart; iy <= bout_mesh->yend; iy++) {
-        local_R_lower_left_vertices.at(icxy) = Rxy_lower_left_corners(ix, iy);
-        local_Z_lower_left_vertices.at(icxy) = Zxy_lower_left_corners(ix, iy);
-        local_R_lower_right_vertices.at(icxy) = Rxy_lower_right_corners(ix, iy);
-        local_Z_lower_right_vertices.at(icxy) = Zxy_lower_right_corners(ix, iy);
-        local_R_upper_right_vertices.at(icxy) = Rxy_upper_right_corners(ix, iy);
-        local_Z_upper_right_vertices.at(icxy) = Zxy_upper_right_corners(ix, iy);
-        local_R_upper_left_vertices.at(icxy) = Rxy_upper_left_corners(ix, iy);
-        local_Z_upper_left_vertices.at(icxy) = Zxy_upper_left_corners(ix, iy);
-        icxy++;
-      }
+  // PETSCCHK(PetscInitializeNoArguments());
+  // auto sycl_target = std::make_shared<SYCLTarget>(0, PETSC_COMM_WORLD);
+  const int mpi_size = sycl_target->comm_pair.size_parent;
+  const int mpi_rank = sycl_target->comm_pair.rank_parent;
+  // output << "Got here 0 \n";
+  // global number of physical nonunique vertices stored in hypnotoad datasets
+  const int N_nonunique_vertices = mpi_size * Nx * Ny;
+  // arrays to fill with local data
+  std::vector<double> local_Z_lower_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_R_lower_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_Z_lower_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_R_lower_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_Z_upper_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_R_upper_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_Z_upper_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> local_R_upper_left_vertices(N_nonunique_vertices, 0.0);
+  // arrays to receive the summed data across ranks
+  std::vector<double> global_Z_lower_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_R_lower_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_Z_lower_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_R_lower_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_Z_upper_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_R_upper_right_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_Z_upper_left_vertices(N_nonunique_vertices, 0.0);
+  std::vector<double> global_R_upper_left_vertices(N_nonunique_vertices, 0.0);
+  // fill these vectors with vertex values from the local rank
+  // at indices determined by the local rank
+  int icxy = Nx * Ny * mpi_rank;
+  for (int ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
+    for (int iy = bout_mesh->ystart; iy <= bout_mesh->yend; iy++) {
+      local_R_lower_left_vertices.at(icxy) = Rxy_lower_left_corners(ix, iy);
+      local_Z_lower_left_vertices.at(icxy) = Zxy_lower_left_corners(ix, iy);
+      local_R_lower_right_vertices.at(icxy) = Rxy_lower_right_corners(ix, iy);
+      local_Z_lower_right_vertices.at(icxy) = Zxy_lower_right_corners(ix, iy);
+      local_R_upper_right_vertices.at(icxy) = Rxy_upper_right_corners(ix, iy);
+      local_Z_upper_right_vertices.at(icxy) = Zxy_upper_right_corners(ix, iy);
+      local_R_upper_left_vertices.at(icxy) = Rxy_upper_left_corners(ix, iy);
+      local_Z_upper_left_vertices.at(icxy) = Zxy_upper_left_corners(ix, iy);
+      icxy++;
     }
-    // Perform Allreduce (sum) to get knowledge of vertices to all ranks
-    MPICHK(MPI_Allreduce(local_R_lower_left_vertices.data(),
-                        global_R_lower_left_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_Z_lower_left_vertices.data(),
-                        global_Z_lower_left_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_R_lower_right_vertices.data(),
-                        global_R_lower_right_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_Z_lower_right_vertices.data(),
-                        global_Z_lower_right_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_R_upper_right_vertices.data(),
-                        global_R_upper_right_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_Z_upper_right_vertices.data(),
-                        global_Z_upper_right_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_R_upper_left_vertices.data(),
-                        global_R_upper_left_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    MPICHK(MPI_Allreduce(local_Z_upper_left_vertices.data(),
-                        global_Z_upper_left_vertices.data(), N_nonunique_vertices,
-                        MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
-    // if (mpi_rank == 0) {
-    //     std::cout << "Result of Allreduce (sum): ";
-    //     for (double val : global_R_lower_left_vertices) {
-    //         std::cout << val << " ";
-    //     }
-    //     std::cout << std::endl;
-    //     std::cout << "N_nonunique_vertices=" << N_nonunique_vertices << std::endl;
+  }
+  // Perform Allreduce (sum) to get knowledge of vertices to all ranks
+  MPICHK(MPI_Allreduce(local_R_lower_left_vertices.data(),
+                       global_R_lower_left_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_Z_lower_left_vertices.data(),
+                       global_Z_lower_left_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_R_lower_right_vertices.data(),
+                       global_R_lower_right_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_Z_lower_right_vertices.data(),
+                       global_Z_lower_right_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_R_upper_right_vertices.data(),
+                       global_R_upper_right_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_Z_upper_right_vertices.data(),
+                       global_Z_upper_right_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_R_upper_left_vertices.data(),
+                       global_R_upper_left_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  MPICHK(MPI_Allreduce(local_Z_upper_left_vertices.data(),
+                       global_Z_upper_left_vertices.data(), N_nonunique_vertices,
+                       MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD));
+  // if (mpi_rank == 0) {
+  //     std::cout << "Result of Allreduce (sum): ";
+  //     for (double val : global_R_lower_left_vertices) {
+  //         std::cout << val << " ";
+  //     }
+  //     std::cout << std::endl;
+  //     std::cout << "N_nonunique_vertices=" << N_nonunique_vertices << std::endl;
+  // }
+  // Now dynamically determine a list of unique vertex points
+  // constant to give us a vector that can definitely contain all points in the global
+  // lists
+  const int N_global_nonunique_vertices = 4 * mpi_size * Nx * Ny;
+  std::vector<double> global_Z_vertices_buffer(N_global_nonunique_vertices, 0.0);
+  std::vector<double> global_R_vertices_buffer(N_global_nonunique_vertices, 0.0);
+  // fill the buffer vectors, checking each time if the point is unique
+  // first point, outside loop
+  global_Z_vertices_buffer.at(0) = global_Z_lower_left_vertices.at(0);
+  global_R_vertices_buffer.at(0) = global_R_lower_left_vertices.at(0);
+  int N_unique = 1; // we have one unique point in the buffer
+  const double tolerance = 1.0e-8;
+  // loop over lower left vertices
+  collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
+                        tolerance, global_Z_lower_left_vertices,
+                        global_R_lower_left_vertices);
+  // loop over lower right vertices
+  collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
+                        tolerance, global_Z_lower_right_vertices,
+                        global_R_lower_right_vertices);
+  // loop over upper right vertices
+  collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
+                        tolerance, global_Z_upper_right_vertices,
+                        global_R_upper_right_vertices);
+  // loop over upper left vertices
+  collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
+                        tolerance, global_Z_upper_left_vertices,
+                        global_R_upper_left_vertices);
+  // now make a vector of the size N_unique and fill from the buffer
+  std::vector<double> global_Z_vertices(N_unique, 0.0);
+  std::vector<double> global_R_vertices(N_unique, 0.0);
+  for (int iv = 0; iv < N_unique; iv++) {
+    global_Z_vertices.at(iv) = global_Z_vertices_buffer.at(iv);
+    global_R_vertices.at(iv) = global_R_vertices_buffer.at(iv);
+  }
+  if (mpi_rank == 0) {
+    std::cout << "Result of vertex collection: ";
+    // for (int iv=0; iv<N_unique; iv++) {
+    //     std::cout << "(" << global_R_vertices.at(iv) << ", " <<
+    //     global_Z_vertices.at(iv) << ") ";
     // }
-    // Now dynamically determine a list of unique vertex points
-    // constant to give us a vector that can definitely contain all points in the global
-    // lists
-    const int N_global_nonunique_vertices = 4 * mpi_size * Nx * Ny;
-    std::vector<double> global_Z_vertices_buffer(N_global_nonunique_vertices, 0.0);
-    std::vector<double> global_R_vertices_buffer(N_global_nonunique_vertices, 0.0);
-    // fill the buffer vectors, checking each time if the point is unique
-    // first point, outside loop
-    global_Z_vertices_buffer.at(0) = global_Z_lower_left_vertices.at(0);
-    global_R_vertices_buffer.at(0) = global_R_lower_left_vertices.at(0);
-    int N_unique = 1; // we have one unique point in the buffer
-    const double tolerance = 1.0e-8;
-    // loop over lower left vertices
-    collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
-                          tolerance, global_Z_lower_left_vertices, global_R_lower_left_vertices);
-    // loop over lower right vertices
-    collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
-                          tolerance, global_Z_lower_right_vertices,
-                          global_R_lower_right_vertices);
-    // loop over upper right vertices
-    collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
-                          tolerance, global_Z_upper_right_vertices,
-                          global_R_upper_right_vertices);
-    // loop over upper left vertices
-    collect_unique_points(global_Z_vertices_buffer, global_R_vertices_buffer, N_unique,
-                          tolerance, global_Z_upper_left_vertices, global_R_upper_left_vertices);
-    // now make a vector of the size N_unique and fill from the buffer
-    std::vector<double> global_Z_vertices(N_unique, 0.0);
-    std::vector<double> global_R_vertices(N_unique, 0.0);
-    for (int iv = 0; iv < N_unique; iv++) {
-      global_Z_vertices.at(iv) = global_Z_vertices_buffer.at(iv);
-      global_R_vertices.at(iv) = global_R_vertices_buffer.at(iv);
-    }
-    if (mpi_rank == 0) {
-      std::cout << "Result of vertex collection: ";
-      // for (int iv=0; iv<N_unique; iv++) {
-      //     std::cout << "(" << global_R_vertices.at(iv) << ", " <<
-      //     global_Z_vertices.at(iv) << ") ";
-      // }
-      // std::cout << std::endl;
-      std::cout << "N_unique=" << N_unique << std::endl;
-    }
-    // ivertex arrays made in cxx, initialise with -1 index
-    Field2D ivertex_lower_left_corners_cxx{-1, bout_mesh};
-    Field2D ivertex_lower_right_corners_cxx{-1, bout_mesh};
-    Field2D ivertex_upper_right_corners_cxx{-1, bout_mesh};
-    Field2D ivertex_upper_left_corners_cxx{-1, bout_mesh};
-    // now fill ivertex_corners arrays
-    RZ_to_ivertex_vector(ivertex_lower_left_corners_cxx, global_Z_vertices,
-                        global_R_vertices, tolerance, bout_mesh, Rxy_lower_left_corners,
-                        Zxy_lower_left_corners);
-    RZ_to_ivertex_vector(ivertex_lower_right_corners_cxx, global_Z_vertices,
-                        global_R_vertices, tolerance, bout_mesh, Rxy_lower_right_corners,
-                        Zxy_lower_right_corners);
-    RZ_to_ivertex_vector(ivertex_upper_right_corners_cxx, global_Z_vertices,
-                        global_R_vertices, tolerance, bout_mesh, Rxy_upper_right_corners,
-                        Zxy_upper_right_corners);
-    RZ_to_ivertex_vector(ivertex_upper_left_corners_cxx, global_Z_vertices,
-                        global_R_vertices, tolerance, bout_mesh, Rxy_upper_left_corners,
-                        Zxy_upper_left_corners);
+    // std::cout << std::endl;
+    std::cout << "N_unique=" << N_unique << std::endl;
+  }
+  // ivertex arrays made in cxx, initialise with -1 index
+  Field2D ivertex_lower_left_corners_cxx{-1, bout_mesh};
+  Field2D ivertex_lower_right_corners_cxx{-1, bout_mesh};
+  Field2D ivertex_upper_right_corners_cxx{-1, bout_mesh};
+  Field2D ivertex_upper_left_corners_cxx{-1, bout_mesh};
+  // now fill ivertex_corners arrays
+  RZ_to_ivertex_vector(ivertex_lower_left_corners_cxx, global_Z_vertices,
+                       global_R_vertices, tolerance, bout_mesh, Rxy_lower_left_corners,
+                       Zxy_lower_left_corners);
+  RZ_to_ivertex_vector(ivertex_lower_right_corners_cxx, global_Z_vertices,
+                       global_R_vertices, tolerance, bout_mesh, Rxy_lower_right_corners,
+                       Zxy_lower_right_corners);
+  RZ_to_ivertex_vector(ivertex_upper_right_corners_cxx, global_Z_vertices,
+                       global_R_vertices, tolerance, bout_mesh, Rxy_upper_right_corners,
+                       Zxy_upper_right_corners);
+  RZ_to_ivertex_vector(ivertex_upper_left_corners_cxx, global_Z_vertices,
+                       global_R_vertices, tolerance, bout_mesh, Rxy_upper_left_corners,
+                       Zxy_upper_left_corners);
 
-    // First we setup the topology of the mesh.
-    PetscInt num_cells_owned = Nx * Ny;
-    // std::vector<double> cells(4*num_cells_owned);
-    std::vector<PetscInt> cells;
-    if (use_cxx_ivertex) {
-      cells_definition_from_RZ_ivertex(
-          cells, bout_mesh, Rxy_lower_left_corners, Rxy_lower_right_corners,
-          Rxy_upper_right_corners, Rxy_upper_left_corners, Zxy_lower_left_corners,
-          Zxy_lower_right_corners, Zxy_upper_right_corners, Zxy_upper_left_corners,
-          ivertex_lower_left_corners_cxx, ivertex_lower_right_corners_cxx,
-          ivertex_upper_right_corners_cxx, ivertex_upper_left_corners_cxx);
-    } else {
-      cells = cells_definition_from_RZ_ivertex(
-          cells, bout_mesh, Rxy_lower_left_corners, Rxy_lower_right_corners,
-          Rxy_upper_right_corners, Rxy_upper_left_corners, Zxy_lower_left_corners,
-          Zxy_lower_right_corners, Zxy_upper_right_corners, Zxy_upper_left_corners,
-          ivertex_lower_left_corners, ivertex_lower_right_corners,
-          ivertex_upper_right_corners, ivertex_upper_left_corners);
-    }
-    // create nvertices, global_vertex_list_R, global_vertex_list_z variables
-    int nvertices;
-    std::vector<double> global_vertex_list_R;
-    std::vector<double> global_vertex_list_Z;
-    if (use_cxx_ivertex) {
-      nvertices = N_unique;
-      global_vertex_list_R = global_R_vertices;
-      global_vertex_list_Z = global_Z_vertices;
-    } else {
-      load_vertex_information_from_netcdf(nvertices, global_vertex_list_R,
-                                          global_vertex_list_Z);
-    }
-    // number of vertices to keep per process for passing to
-    // DMPlexCreateFromCellListParallelPetsc
-    int nvertex_per_process = std::floor(nvertices / mpi_size);
-    int nvertex_remainder = nvertices - mpi_size * nvertex_per_process;
-    int nvertex_this_process = nvertex_per_process;
-    // include the remaining vertices on the last rank
-    if (mpi_rank == mpi_size - 1) {
-      nvertex_this_process += nvertex_remainder;
-    }
-    // starting vertex index
-    int ivertex_minimum = mpi_rank * nvertex_per_process;
-    int ivertex_maximum = mpi_rank * nvertex_per_process + nvertex_this_process - 1;
-    /*
-    * Each rank owns a contiguous block of global indices. We label our indices
-    * lexicographically (row-wise). Sorting out the global vertex indexing is
-    * probably one of the more tedious parts.
-    */
-    PetscInt num_vertices_owned = nvertex_this_process;
+  // First we setup the topology of the mesh.
+  PetscInt num_cells_owned = Nx * Ny;
+  // std::vector<double> cells(4*num_cells_owned);
+  std::vector<PetscInt> cells;
+  if (use_cxx_ivertex) {
+    cells_definition_from_RZ_ivertex(
+        cells, bout_mesh, Rxy_lower_left_corners, Rxy_lower_right_corners,
+        Rxy_upper_right_corners, Rxy_upper_left_corners, Zxy_lower_left_corners,
+        Zxy_lower_right_corners, Zxy_upper_right_corners, Zxy_upper_left_corners,
+        ivertex_lower_left_corners_cxx, ivertex_lower_right_corners_cxx,
+        ivertex_upper_right_corners_cxx, ivertex_upper_left_corners_cxx);
+  } else {
+    cells = cells_definition_from_RZ_ivertex(
+        cells, bout_mesh, Rxy_lower_left_corners, Rxy_lower_right_corners,
+        Rxy_upper_right_corners, Rxy_upper_left_corners, Zxy_lower_left_corners,
+        Zxy_lower_right_corners, Zxy_upper_right_corners, Zxy_upper_left_corners,
+        ivertex_lower_left_corners, ivertex_lower_right_corners,
+        ivertex_upper_right_corners, ivertex_upper_left_corners);
+  }
+  // create nvertices, global_vertex_list_R, global_vertex_list_z variables
+  int nvertices;
+  std::vector<double> global_vertex_list_R;
+  std::vector<double> global_vertex_list_Z;
+  if (use_cxx_ivertex) {
+    nvertices = N_unique;
+    global_vertex_list_R = global_R_vertices;
+    global_vertex_list_Z = global_Z_vertices;
+  } else {
+    load_vertex_information_from_netcdf(nvertices, global_vertex_list_R,
+                                        global_vertex_list_Z);
+  }
+  // number of vertices to keep per process for passing to
+  // DMPlexCreateFromCellListParallelPetsc
+  int nvertex_per_process = std::floor(nvertices / mpi_size);
+  int nvertex_remainder = nvertices - mpi_size * nvertex_per_process;
+  int nvertex_this_process = nvertex_per_process;
+  // include the remaining vertices on the last rank
+  if (mpi_rank == mpi_size - 1) {
+    nvertex_this_process += nvertex_remainder;
+  }
+  // starting vertex index
+  int ivertex_minimum = mpi_rank * nvertex_per_process;
+  int ivertex_maximum = mpi_rank * nvertex_per_process + nvertex_this_process - 1;
+  /*
+   * Each rank owns a contiguous block of global indices. We label our indices
+   * lexicographically (row-wise). Sorting out the global vertex indexing is
+   * probably one of the more tedious parts.
+   */
+  PetscInt num_vertices_owned = nvertex_this_process;
 
-    /*
-    * Create the coordinates for the block of vertices we pass to petsc. For an
-    * existing mesh in memory this step will probably involve some MPI
-    * communication to gather the blocks of coordinates on the ranks which pass
-    * them to PETSc.
-    */
-    std::vector<PetscScalar> vertex_coords(num_vertices_owned * 2);
-    // shift due to differing rank
-    int ishift;
-    for (int iv = 0; iv < nvertex_this_process; iv++) {
-      ishift = mpi_rank * nvertex_per_process;
-      vertex_coords.at(iv * 2 + 0) = global_vertex_list_R[iv + ishift];
-      vertex_coords.at(iv * 2 + 1) = global_vertex_list_Z[iv + ishift];
-    }
-    // This DM will contain the DMPlex after we call the creation routine.
-    DM dm;
-    // Create the DMPlex from the cells and coordinates.
-    PETSCCHK(DMPlexCreateFromCellListParallelPetsc(
-        PETSC_COMM_WORLD, 2, num_cells_owned, num_vertices_owned, PETSC_DECIDE, 4,
-        PETSC_TRUE, cells.data(), 2, vertex_coords.data(), NULL, NULL, &dm));
+  /*
+   * Create the coordinates for the block of vertices we pass to petsc. For an
+   * existing mesh in memory this step will probably involve some MPI
+   * communication to gather the blocks of coordinates on the ranks which pass
+   * them to PETSc.
+   */
+  std::vector<PetscScalar> vertex_coords(num_vertices_owned * 2);
+  // shift due to differing rank
+  int ishift;
+  for (int iv = 0; iv < nvertex_this_process; iv++) {
+    ishift = mpi_rank * nvertex_per_process;
+    vertex_coords.at(iv * 2 + 0) = global_vertex_list_R[iv + ishift];
+    vertex_coords.at(iv * 2 + 1) = global_vertex_list_Z[iv + ishift];
+  }
+  // This DM will contain the DMPlex after we call the creation routine.
+  DM dm;
+  // Create the DMPlex from the cells and coordinates.
+  PETSCCHK(DMPlexCreateFromCellListParallelPetsc(
+      PETSC_COMM_WORLD, 2, num_cells_owned, num_vertices_owned, PETSC_DECIDE, 4,
+      PETSC_TRUE, cells.data(), 2, vertex_coords.data(), NULL, NULL, &dm));
 
-    // Label all of the boundary faces with 100 in the "Face Sets" label by using
-    // the helper function label_all_dmplex_boundaries.
-    PetscInterface::label_all_dmplex_boundaries(dm, PetscInterface::face_sets_label, 100);
+  // Label all of the boundary faces with 100 in the "Face Sets" label by using
+  // the helper function label_all_dmplex_boundaries.
+  PetscInterface::label_all_dmplex_boundaries(dm, PetscInterface::face_sets_label, 100);
 
-    // // Label subsections of the boundary by specifing pairs of vertices and using
-    // // the label_dmplex_edges helper function.
-    // std::vector<PetscInt> vertex_starts, vertex_ends, edge_labels;
+  // // Label subsections of the boundary by specifing pairs of vertices and using
+  // // the label_dmplex_edges helper function.
+  // std::vector<PetscInt> vertex_starts, vertex_ends, edge_labels;
 
-    // if (mpi_rank == mpi_size - 1) {
-    //   // Top edge
-    //   for (int px = 0; px < mpi_size; px++) {
-    //     const PetscInt tx = (mpi_size + 1) * mpi_size + px;
-    //     vertex_starts.push_back(tx);
-    //     vertex_ends.push_back(tx + 1);
-    //     // Label the top edge with label 200
-    //     edge_labels.push_back(200);
-    //   }
-    // }
+  // if (mpi_rank == mpi_size - 1) {
+  //   // Top edge
+  //   for (int px = 0; px < mpi_size; px++) {
+  //     const PetscInt tx = (mpi_size + 1) * mpi_size + px;
+  //     vertex_starts.push_back(tx);
+  //     vertex_ends.push_back(tx + 1);
+  //     // Label the top edge with label 200
+  //     edge_labels.push_back(200);
+  //   }
+  // }
 
-    // PetscInterface::label_dmplex_edges(dm, PetscInterface::face_sets_label,
-    //                                    vertex_starts, vertex_ends, edge_labels);
+  // PetscInterface::label_dmplex_edges(dm, PetscInterface::face_sets_label,
+  //                                    vertex_starts, vertex_ends, edge_labels);
 
-    // save a HDF5 file containing the DM for diagnostics
-    PetscViewer viewer;
-    // Set a name for the DMPlex object (important for HDF5)
-    PetscObjectSetName((PetscObject)dm, dmplex_name.c_str());
-    // Create an HDF5 viewer
-    PetscViewerHDF5Open(PETSC_COMM_WORLD, dmplex_h5_filename.c_str(), FILE_MODE_WRITE,
-                        &viewer);
-    // Set viewer format to PETSC_VIEWER_HDF5_PETSC for compatibility
-    PetscViewerPushFormat(viewer, PETSC_VIEWER_HDF5_PETSC);
-    // Save the DMPlex to the HDF5 file
-    DMView(dm, viewer);
-    // Clean up
-    PetscViewerDestroy(&viewer);
-    output << "Finished DMPlex creation and diagnostic \n";
-    return dm;
+  // save a HDF5 file containing the DM for diagnostics
+  PetscViewer viewer;
+  // Set a name for the DMPlex object (important for HDF5)
+  PetscObjectSetName((PetscObject)dm, dmplex_name.c_str());
+  // Create an HDF5 viewer
+  PetscViewerHDF5Open(PETSC_COMM_WORLD, dmplex_h5_filename.c_str(), FILE_MODE_WRITE,
+                      &viewer);
+  // Set viewer format to PETSC_VIEWER_HDF5_PETSC for compatibility
+  PetscViewerPushFormat(viewer, PETSC_VIEWER_HDF5_PETSC);
+  // Save the DMPlex to the HDF5 file
+  DMView(dm, viewer);
+  // Clean up
+  PetscViewerDestroy(&viewer);
+  output << "Finished DMPlex creation and diagnostic \n";
+  return dm;
 }
 
-void extract_ionised_density_in_place(Field2D& density,
-      std::shared_ptr<CellwiseAccumulator<double>>& accumulator_transform,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::shared_ptr<TransformationStrategy>& source_zeroer,
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh) {
+void extract_ionised_density_in_place(
+    Field2D& density, std::shared_ptr<CellwiseAccumulator<double>>& accumulator_transform,
+    std::shared_ptr<ParticleGroup>& A_particle_group,
+    std::shared_ptr<TransformationStrategy>& source_zeroer,
+    std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh) {
   Mesh* bout_mesh = density.getMesh();
-  std::vector<CellData<double>> accumulated_1d = accumulator_transform->get_cell_data("ION_SOURCE_DENSITY");
+  std::vector<CellData<double>> accumulated_1d =
+      accumulator_transform->get_cell_data("ION_SOURCE_DENSITY");
   PetscInt ic = 0;
   for (PetscInt ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
     for (PetscInt iy = bout_mesh->ystart; iy <= bout_mesh->yend; iy++) {
-      density(ix, iy) += accumulated_1d[ic]->at(0,0)/neso_mesh->dmh->get_cell_volume(ic);
+      density(ix, iy) +=
+          accumulated_1d[ic]->at(0, 0) / neso_mesh->dmh->get_cell_volume(ic);
       ic++;
     }
   }
@@ -513,10 +518,9 @@ void extract_ionised_density_in_place(Field2D& density,
   source_zeroer->transform(std::make_shared<ParticleSubGroup>(A_particle_group));
 }
 
-void calculate_density_in_place(Field2D& density,
-      std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::vector<double>& h_project1) {
+void calculate_density_in_place(
+    Field2D& density, std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
+    std::shared_ptr<ParticleGroup>& A_particle_group, std::vector<double>& h_project1) {
   Mesh* bout_mesh = density.getMesh();
   // get a density by projecting the particle property WEIGHT to the bout_mesh
   dg0->project(A_particle_group, Sym<REAL>("WEIGHT"));
@@ -536,43 +540,45 @@ void calculate_density_in_place(Field2D& density,
   // extrapolate -> Neumann
 }
 
-void calculate_fluid_moments_in_place(Field2D& neutral_density, Field2D& ion_density,
-      std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::vector<double>& h_project1,
-      std::shared_ptr<CellwiseAccumulator<double>>& accumulator_transform,
-      std::shared_ptr<TransformationStrategy>& source_zeroer,
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh){
+void calculate_fluid_moments_in_place(
+    Field2D& neutral_density, Field2D& ion_density,
+    std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
+    std::shared_ptr<ParticleGroup>& A_particle_group, std::vector<double>& h_project1,
+    std::shared_ptr<CellwiseAccumulator<double>>& accumulator_transform,
+    std::shared_ptr<TransformationStrategy>& source_zeroer,
+    std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh) {
   // calculate all of the fluid moments required for the moment, from data in
   // the particle group. Set to zero any particle properties needed in preparation
   // for the next time step.
   calculate_density_in_place(neutral_density, dg0, A_particle_group, h_project1);
-  extract_ionised_density_in_place(ion_density, accumulator_transform, A_particle_group, source_zeroer, neso_mesh);
+  extract_ionised_density_in_place(ion_density, accumulator_transform, A_particle_group,
+                                   source_zeroer, neso_mesh);
 }
 
-double calculate_total_mass(Field2D& density, std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh){
-  double local_mass=0.0;
-  double total_mass=0.0;
+double calculate_total_mass(Field2D& density,
+                            std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh) {
+  double local_mass = 0.0;
+  double total_mass = 0.0;
   Mesh* bout_mesh = density.getMesh();
   PetscInt ic = 0;
   for (PetscInt ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
     for (PetscInt iy = bout_mesh->ystart; iy <= bout_mesh->yend; iy++) {
-      local_mass += density(ix, iy)*neso_mesh->dmh->get_cell_volume(ic);
+      local_mass += density(ix, iy) * neso_mesh->dmh->get_cell_volume(ic);
       ic++;
     }
   }
-  MPICHK(MPI_Allreduce(&local_mass,
-                       &total_mass, 1,
-                        MPI_DOUBLE, MPI_SUM, BoutComm::get()));
+  MPICHK(
+      MPI_Allreduce(&local_mass, &total_mass, 1, MPI_DOUBLE, MPI_SUM, BoutComm::get()));
   return total_mass;
 }
 
-Options initialise_diagnostics(Field2D& neutral_density, Field2D & ion_density,
-      std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
-      std::vector<double>& h_project1,
-      std::string particle_data_filename){
+Options
+initialise_diagnostics(Field2D& neutral_density, Field2D& ion_density,
+                       std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
+                       std::shared_ptr<ParticleGroup>& A_particle_group,
+                       std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
+                       std::vector<double>& h_project1,
+                       std::string particle_data_filename) {
   // Options object to use to write out diagnostic data of fluid quantities
   Options bout_output_data;
   bout_output_data["neutral_density"] = neutral_density;
@@ -580,41 +586,45 @@ Options initialise_diagnostics(Field2D& neutral_density, Field2D & ion_density,
   bout_output_data["neutral_density"].attributes["time_dimension"] = "t";
   bout_output_data["ion_density"] = ion_density;
   bout_output_data["ion_density"].attributes["time_dimension"] = "t";
-  bout_output_data["total_neutral_mass"] = calculate_total_mass(neutral_density, neso_mesh);
+  bout_output_data["total_neutral_mass"] =
+      calculate_total_mass(neutral_density, neso_mesh);
   bout_output_data["total_neutral_mass"].attributes["time_dimension"] = "t";
   bout_output_data["total_ion_mass"] = calculate_total_mass(ion_density, neso_mesh);
   bout_output_data["total_ion_mass"].attributes["time_dimension"] = "t";
-  Field2D total_density = ion_density+neutral_density;
+  Field2D total_density = ion_density + neutral_density;
   bout_output_data["total_mass"] = calculate_total_mass(total_density, neso_mesh);
   bout_output_data["total_mass"].attributes["time_dimension"] = "t";
-  // std::string particle_data_filename = fmt::format("bout_particle_moments_{}.nc",mpi_rank);
+  // std::string particle_data_filename =
+  // fmt::format("bout_particle_moments_{}.nc",mpi_rank);
   bout::OptionsIO::create(particle_data_filename)->write(bout_output_data);
   return bout_output_data;
 }
 
 void update_diagnostics(Field2D& neutral_density, Field2D& ion_density,
-      std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
-      std::vector<double>& h_project1,
-      Options& bout_output_data,
-      std::string particle_data_filename){
+                        std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
+                        std::shared_ptr<ParticleGroup>& A_particle_group,
+                        std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
+                        std::vector<double>& h_project1, Options& bout_output_data,
+                        std::string particle_data_filename) {
   // update density in Options object and write
   bout_output_data["neutral_density"] = neutral_density;
   bout_output_data["ion_density"] = ion_density;
-  Field2D total_density = ion_density+neutral_density;
+  Field2D total_density = ion_density + neutral_density;
   bout_output_data["total_mass"] = calculate_total_mass(total_density, neso_mesh);
-  bout_output_data["total_neutral_mass"] = calculate_total_mass(neutral_density, neso_mesh);
+  bout_output_data["total_neutral_mass"] =
+      calculate_total_mass(neutral_density, neso_mesh);
   bout_output_data["total_ion_mass"] = calculate_total_mass(ion_density, neso_mesh);
   // Append data to file
-  bout::OptionsIO::create({{"file", particle_data_filename}, {"append", true}})->write(bout_output_data);
+  bout::OptionsIO::create({{"file", particle_data_filename}, {"append", true}})
+      ->write(bout_output_data);
 }
 
-void set_initial_particle_weights(Field2D& initial_neutral_density,
-      std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
-      std::shared_ptr<ParticleGroup>& A_particle_group,
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
-      std::vector<double>& h_project1){
+void set_initial_particle_weights(
+    Field2D& initial_neutral_density,
+    std::shared_ptr<PetscInterface::DMPlexProjectEvaluateDG>& dg0,
+    std::shared_ptr<ParticleGroup>& A_particle_group,
+    std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
+    std::vector<double>& h_project1) {
   Mesh* bout_mesh = initial_neutral_density.getMesh();
   PetscInt ixy = 0;
   for (PetscInt ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
@@ -624,7 +634,8 @@ void set_initial_particle_weights(Field2D& initial_neutral_density,
       // then divide by the number of marker particles per cell
       const REAL cell_volume = neso_mesh->dmh->get_cell_volume(ixy);
       const INT nmarkers_per_cell = A_particle_group->get_npart_cell(ixy);
-      const REAL particle_weights = initial_neutral_density(ix, iy)*cell_volume/nmarkers_per_cell;
+      const REAL particle_weights =
+          initial_neutral_density(ix, iy) * cell_volume / nmarkers_per_cell;
       h_project1.at(ixy) = particle_weights;
       ixy++;
     }
@@ -635,21 +646,23 @@ void set_initial_particle_weights(Field2D& initial_neutral_density,
   dg0->evaluate(A_particle_group, Sym<REAL>("WEIGHT"));
 }
 
-void check_cell_volumes(
-      std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
-      Mesh*& bout_mesh){
+void check_cell_volumes(std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
+                        Mesh*& bout_mesh) {
   Coordinates* coord = bout_mesh->getCoordinates();
   PetscInt ixy = 0;
   const REAL tolerance = 1.0e-12;
   for (PetscInt ix = bout_mesh->xstart; ix <= bout_mesh->xend; ix++) {
     for (PetscInt iy = bout_mesh->ystart; iy <= bout_mesh->yend; iy++) {
-      const REAL bout_cell_volume = coord->J(ix,iy)*
-                                coord->dx(ix,iy)*coord->dy(ix,iy);
+      const REAL bout_cell_volume =
+          coord->J(ix, iy) * coord->dx(ix, iy) * coord->dy(ix, iy);
       const REAL neso_cell_volume = neso_mesh->dmh->get_cell_volume(ixy);
       const bool volumes_match = (abs(bout_cell_volume - neso_cell_volume) < tolerance);
       // exit if we fail to find a match
       NESOASSERT(volumes_match,
-                 fmt::format("BOUT++ mesh volume {} does not match NESO-Particles mesh volume {} for ix = {} iy = {} \n Ignore this message by setting [neso_particles] test_cell_volumes = false", bout_cell_volume, neso_cell_volume, ix, iy));
+                 fmt::format("BOUT++ mesh volume {} does not match NESO-Particles mesh "
+                             "volume {} for ix = {} iy = {} \n Ignore this message by "
+                             "setting [neso_particles] test_cell_volumes = false",
+                             bout_cell_volume, neso_cell_volume, ix, iy));
       ixy++;
     }
   }
@@ -706,7 +719,7 @@ int main(int argc, char** argv) {
     int num_cells_owned = neso_mesh->get_cell_count();
     // if requested, check that neso_mesh cell volumes are identical
     // to bout_mesh cell volumes, otherwise, exit.
-    if (Options::root()["neso_particles"]["test_cell_volumes"].withDefault(true)){
+    if (Options::root()["neso_particles"]["test_cell_volumes"].withDefault(true)) {
       check_cell_volumes(neso_mesh, bout_mesh);
     }
     // create a Reactions particle spec
@@ -715,21 +728,21 @@ int main(int argc, char** argv) {
     auto main_species = Species("ION", 1.0, 0.0, 0);
     std::vector<Species> fluid_species = {electron_species, main_species};
     particle_spec_builder.add_particle_prop(Properties<REAL>(
-        fluid_species, std::vector<int>{default_properties.temperature,
-                                        default_properties.density,
-                                        default_properties.source_energy,
-                                        default_properties.source_density}));
+        fluid_species,
+        std::vector<int>{default_properties.temperature, default_properties.density,
+                         default_properties.source_energy,
+                         default_properties.source_density}));
     particle_spec_builder.add_particle_prop(
         Properties<REAL>(fluid_species,
-                        std::vector<int>{default_properties.source_momentum}),
+                         std::vector<int>{default_properties.source_momentum}),
         ndim);
-    ParticleSpec additional_props{
-      ParticleProp(Sym<REAL>("TSP"), 2)};
+    ParticleSpec additional_props{ParticleProp(Sym<REAL>("TSP"), 2)};
     particle_spec_builder.add_particle_spec(additional_props);
     ParticleSpec particle_spec = particle_spec_builder.get_particle_spec();
 
     // Create a Particle group with our specied particle properties.
-    auto A_particle_group = std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+    auto A_particle_group =
+        std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
 
     // Create some particle data
     const int mpi_rank = sycl_target->comm_pair.rank_parent;
@@ -738,7 +751,8 @@ int main(int argc, char** argv) {
     std::vector<std::vector<double>> positions;
     std::vector<int> particle_cell_ids;
 
-    uniform_within_dmplex_cells(neso_mesh, npart_per_cell, positions, particle_cell_ids, &rng_pos);
+    uniform_within_dmplex_cells(neso_mesh, npart_per_cell, positions, particle_cell_ids,
+                                &rng_pos);
 
     const int N_actual = particle_cell_ids.size();
     auto velocities =
@@ -783,40 +797,42 @@ int main(int argc, char** argv) {
         electron_species);
 
     // Reaction controllers
-    const REAL remove_threshold = Options::root()["VANTAGE_reactions"]["remove_threshold"].withDefault(1.0e-10);
-    const REAL merge_threshold = Options::root()["VANTAGE_reactions"]["merge_threshold"].withDefault(1.0e-2);
+    const REAL remove_threshold =
+        Options::root()["VANTAGE_reactions"]["remove_threshold"].withDefault(1.0e-10);
+    const REAL merge_threshold =
+        Options::root()["VANTAGE_reactions"]["merge_threshold"].withDefault(1.0e-2);
 
     auto remove_wrapper = std::make_shared<TransformationWrapper>(
-      std::vector<std::shared_ptr<MarkingStrategy>>{
-          make_marking_strategy<ComparisonMarkerSingle<REAL, LessThanComp>>(
-              Sym<REAL>("WEIGHT"), remove_threshold)},
-      std::dynamic_pointer_cast<TransformationStrategy>(std::make_shared<SimpleRemovalTransformationStrategy>()));
+        std::vector<std::shared_ptr<MarkingStrategy>>{
+            make_marking_strategy<ComparisonMarkerSingle<REAL, LessThanComp>>(
+                Sym<REAL>("WEIGHT"), remove_threshold)},
+        std::dynamic_pointer_cast<TransformationStrategy>(
+            std::make_shared<SimpleRemovalTransformationStrategy>()));
 
     auto merge_wrapper = std::make_shared<TransformationWrapper>(
-      std::vector<std::shared_ptr<MarkingStrategy>>{
-          make_marking_strategy<ComparisonMarkerSingle<REAL, LessThanComp>>(
-              Sym<REAL>("WEIGHT"), merge_threshold)},
-      make_transformation_strategy<MergeTransformationStrategy<ndim>>());
+        std::vector<std::shared_ptr<MarkingStrategy>>{
+            make_marking_strategy<ComparisonMarkerSingle<REAL, LessThanComp>>(
+                Sym<REAL>("WEIGHT"), merge_threshold)},
+        make_transformation_strategy<MergeTransformationStrategy<ndim>>());
 
     auto accumulator_transform = std::make_shared<CellwiseAccumulator<REAL>>(
-                              A_particle_group,
-                              std::vector<std::string>{"ION_SOURCE_DENSITY"});
-    // std::vector<CellData<double>> accumulated_1d = accumulator_transform->get_cell_data("ION_SOURCE_DENSITY");
-    auto accumulator_real_transform_wrapper =
-        std::make_shared<TransformationWrapper>(
-            std::dynamic_pointer_cast<TransformationStrategy>(
-                accumulator_transform));
+        A_particle_group, std::vector<std::string>{"ION_SOURCE_DENSITY"});
+    // std::vector<CellData<double>> accumulated_1d =
+    // accumulator_transform->get_cell_data("ION_SOURCE_DENSITY");
+    auto accumulator_real_transform_wrapper = std::make_shared<TransformationWrapper>(
+        std::dynamic_pointer_cast<TransformationStrategy>(accumulator_transform));
     auto source_zeroer = make_transformation_strategy<ParticleDatZeroer<REAL>>(
-      std::vector<std::string>{"ION_SOURCE_DENSITY"});
+        std::vector<std::string>{"ION_SOURCE_DENSITY"});
 
+    std::vector<std::shared_ptr<TransformationWrapper>> child_transforms =
+        std::vector{merge_wrapper, remove_wrapper};
+    std::vector<std::shared_ptr<TransformationWrapper>> parent_transforms =
+        std::vector{accumulator_real_transform_wrapper, merge_wrapper, remove_wrapper};
 
-    std::vector<std::shared_ptr<TransformationWrapper>> child_transforms = std::vector{merge_wrapper,remove_wrapper};
-    std::vector<std::shared_ptr<TransformationWrapper>> parent_transforms = std::vector{accumulator_real_transform_wrapper,merge_wrapper,remove_wrapper};
-
-    auto reaction_controller =
-        ReactionController(parent_transforms, child_transforms);
+    auto reaction_controller = ReactionController(parent_transforms, child_transforms);
     // add ionisation to the controller
-    reaction_controller.add_reaction(std::make_shared<decltype(ionisation_reaction)>(ionisation_reaction));
+    reaction_controller.add_reaction(
+        std::make_shared<decltype(ionisation_reaction)>(ionisation_reaction));
 
     // Create the boundary interaction objects
     std::map<PetscInt, std::vector<PetscInt>> boundary_groups;
@@ -830,8 +846,8 @@ int main(int argc, char** argv) {
     auto lambda_apply_boundary_conditions = [&](auto aa) {
       auto sub_groups = b2d->post_integration(aa);
       for (auto& gx : sub_groups) {
-        reflection->execute(gx.second, Sym<REAL>("POSITION"), Sym<REAL>("VELOCITY"), Sym<REAL>("TSP"),
-                            b2d->previous_position_sym);
+        reflection->execute(gx.second, Sym<REAL>("POSITION"), Sym<REAL>("VELOCITY"),
+                            Sym<REAL>("TSP"), b2d->previous_position_sym);
       }
     };
     auto lambda_apply_timestep_reset = [&](auto aa) {
@@ -857,8 +873,7 @@ int main(int argc, char** argv) {
               TSP.at(1) = dt_left;
             }
           },
-          Access::read(Sym<REAL>("VELOCITY")),
-          Access::write(Sym<REAL>("POSITION")),
+          Access::read(Sym<REAL>("VELOCITY")), Access::write(Sym<REAL>("POSITION")),
           Access::write(Sym<REAL>("TSP")))
           ->execute();
     };
@@ -886,21 +901,25 @@ int main(int argc, char** argv) {
       }
     };
     // uncomment to write a trajectory
-    H5Part h5part("traj_reflection_dmplex_example.h5part", A_particle_group, Sym<REAL>("POSITION"),
-                  Sym<REAL>("VELOCITY"));
+    H5Part h5part("traj_reflection_dmplex_example.h5part", A_particle_group,
+                  Sym<REAL>("POSITION"), Sym<REAL>("VELOCITY"));
 
-    // allocate buffer vector for scalar projection/evaluation of NESO-Particles properties
+    // allocate buffer vector for scalar projection/evaluation of NESO-Particles
+    // properties
     std::vector<REAL> h_project1(num_cells_owned);
     // set weights from a Field2D from BOUT
-    set_initial_particle_weights(initial_neutral_density, dg0, A_particle_group, neso_mesh, h_project1);
+    set_initial_particle_weights(initial_neutral_density, dg0, A_particle_group,
+                                 neso_mesh, h_project1);
     // update fluid moments
-    calculate_fluid_moments_in_place(neutral_density, ion_density,
-      dg0, A_particle_group, h_project1, accumulator_transform, source_zeroer, neso_mesh);
+    calculate_fluid_moments_in_place(neutral_density, ion_density, dg0, A_particle_group,
+                                     h_project1, accumulator_transform, source_zeroer,
+                                     neso_mesh);
     // diagnose the initial condition
-    std::string particle_data_filename = fmt::format("bout_particle_moments_{}.nc",mpi_rank);
-    Options bout_output_data = initialise_diagnostics(neutral_density, ion_density,
-        dg0, A_particle_group,
-        neso_mesh,h_project1, particle_data_filename);
+    std::string particle_data_filename =
+        fmt::format("bout_particle_moments_{}.nc", mpi_rank);
+    Options bout_output_data =
+        initialise_diagnostics(neutral_density, ion_density, dg0, A_particle_group,
+                               neso_mesh, h_project1, particle_data_filename);
     // begin timestepping
     for (int stepx = 0; stepx < nsteps; stepx++) {
       // nprint("step:", stepx);
@@ -913,13 +932,14 @@ int main(int argc, char** argv) {
       // uncomment to write a trajectory
       h5part.write();
       // uncomment to print particle info
-      // A_particle_group->print(Sym<REAL>("POSITION"), Sym<INT>("ID"), Sym<REAL>("WEIGHT"), Sym<REAL>("ION_SOURCE_DENSITY"));
-      // update fluid moments
-      calculate_fluid_moments_in_place(neutral_density, ion_density,
-        dg0, A_particle_group, h_project1, accumulator_transform, source_zeroer, neso_mesh);
+      // A_particle_group->print(Sym<REAL>("POSITION"), Sym<INT>("ID"),
+      // Sym<REAL>("WEIGHT"), Sym<REAL>("ION_SOURCE_DENSITY")); update fluid moments
+      calculate_fluid_moments_in_place(neutral_density, ion_density, dg0,
+                                       A_particle_group, h_project1,
+                                       accumulator_transform, source_zeroer, neso_mesh);
       // diagnose timestep stepx
       update_diagnostics(neutral_density, ion_density, dg0, A_particle_group, neso_mesh,
-        h_project1, bout_output_data, particle_data_filename);
+                         h_project1, bout_output_data, particle_data_filename);
     }
 
     // uncomment to write a trajectory

--- a/bout-particle-push.cxx
+++ b/bout-particle-push.cxx
@@ -649,7 +649,7 @@ void check_cell_volumes(
       const bool volumes_match = (abs(bout_cell_volume - neso_cell_volume) < tolerance);
       // exit if we fail to find a match
       NESOASSERT(volumes_match,
-                 fmt::format("BOUT++ mesh volume {} does not match NESO-Particles mesh volume {} for ix = {} iy = {}", bout_cell_volume, neso_cell_volume, ix, iy));
+                 fmt::format("BOUT++ mesh volume {} does not match NESO-Particles mesh volume {} for ix = {} iy = {} \n Ignore this message by setting [neso_particles] test_cell_volumes = false", bout_cell_volume, neso_cell_volume, ix, iy));
       ixy++;
     }
   }
@@ -706,7 +706,7 @@ int main(int argc, char** argv) {
     int num_cells_owned = neso_mesh->get_cell_count();
     // if requested, check that neso_mesh cell volumes are identical
     // to bout_mesh cell volumes, otherwise, exit.
-    if (Options::root()["neso_particles"]["test_cell_volumes"].withDefault(false)){
+    if (Options::root()["neso_particles"]["test_cell_volumes"].withDefault(true)){
       check_cell_volumes(neso_mesh, bout_mesh);
     }
     // create a Reactions particle spec

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -30,7 +30,7 @@ Zxy_lower_right_corners = y - 0.5*dy
 Zxy_upper_left_corners = y + 0.5*dy
 Zxy_upper_right_corners = y + 0.5*dy
 
-initial_density = 1.0
+initial_neutral_density = 1.0
 
 [neso_particles]
 npart_per_cell = 1


### PR DESCRIPTION
This PR confirms that ionisation reactions conserve mass in a slab. Mass is conserved to `~ 1.0e-14` if `remove_threshold` is set lower than the weights of the marker particles. Note that increasing the number of particles per cell at fixed density reduces the weight per marker, requiring a lower value of `remove_threshold` for conservation.

The test is controlled by 
```
[neso_particles]
test_mass_conservation = true
```

This PR also makes a check of the DMPlex cell volume compared to the BOUT++ cell volume. The test is performed by default, causing the run to exit, unless the following is included in the `BOUT.inp` file.
```
[neso_particles]
test_cell_volumes = false
```
We find that the slab geometry has identical volumes, as presently calculated, whereas for a hypnotoad geometry, the cell volumes are not exactly identical.