### PR TITLE
Reactions pkg namechange

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -21,7 +21,7 @@ spack:
     unify: when_possible
   repos:
   - ./external/BOUT-spack
-  - ./external/Reactions/Reactions-repo
+  - ./external/Reactions/VANTAGE-repo
   - ./external/Reactions/NESO-Spack
   - $spack/var/spack/repos/builtin
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - hermes-3%gcc+petsc+reactions ^py-numpy@1.26.4 ^vantage-reactions.reactions~nvcxx+enable_tests
+  - hermes-3%gcc+petsc+vantagereactions ^py-numpy@1.26.4 ^vantage.vantagereactions~nvcxx+enable_tests
     ^neso.neso-particles~nvcxx+petsc+build_tests ^openblas ^neso.adaptivecpp ^hdf5
   - cmake@3.30.5
   - py-meshio
@@ -37,9 +37,9 @@ spack:
     hermes-3:
       path: .
       spec: hermes-3@develop
-    reactions:
+    vantagereactions:
       path: ./external/Reactions
-      spec: reactions@working
+      spec: vantagereactions@working
     neso-particles:
       path: ./external/Reactions/neso-particles
       spec: neso-particles@working


### PR DESCRIPTION
A PR with changes by @oparry-ukaea to use the new package name `vantagereactions` in the `spack` installation. This PR is not yet ready to merge.

This PR makes the following changes
 - Updates the version of BOUT-Spack.
 - Updates the expected path to the directory containing the VANTAGE-Reactions `repo.yaml` file (see https://github.com/UKAEA-Edge-Code/VANTAGE-Reactions/pull/188).
 - Updates the spack.yaml  file to use the new `vantagereactions`  name when defining variants of Hermes-3.

Since https://github.com/UKAEA-Edge-Code/VANTAGE-Reactions/pull/188 is not yet merged into `main` or `dev`, and this repository uses a historic version of VANTAGE-Reactions `dev`, but with `spack v0.23.1` (rather than `spack v1.0.2`, which is now the version used by VANTAGE-Reactions), we have not yet updated the `external/Reactions`  commit. Therefore, the branch in this PR will not be able to compile VANTAGE-Reactions features by setting `HERMES_USE_VANTAGE=ON` and will likely fail on the compilation stage with `HERMES_USE_VANTAGE=ON`. This PR will be updated when a compatible version of VANTAGE-Reactions is ready.