### PR TITLE
`bout-particle-push` CI test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,14 @@ if(HERMES_TESTS)
            COMMAND python3 neutral_mixed_ddt_test.py)
     set_tests_properties(rhs_mms_neutral_mixed PROPERTIES LABELS integration)
   endif()
+
+  # Integrated tests of VANTAGE-Reactions+NESO-Particles features
+  if(HERMES_USE_VANTAGE)
+    add_test(NAME bout_particle_push
+           WORKING_DIRECTORY tests/integrated/particle-pusher/
+           COMMAND runtest)
+    set_tests_properties(bout_particle_push PROPERTIES LABELS integration)
+  endif()
 endif()
 
 # Compile-time options

--- a/bout-particle-push.cxx
+++ b/bout-particle-push.cxx
@@ -4,6 +4,8 @@
 #include "bout/output.hxx"
 #include "bout/petsclib.hxx"
 #include <bout/field_factory.hxx>
+#include <algorithm>
+#include <cmath>
 #include <fmt/core.h>
 #include <iostream>
 #include <memory>
@@ -669,8 +671,18 @@ void check_cell_volumes(std::shared_ptr<PetscInterface::DMPlexInterface>& neso_m
   }
 }
 
+REAL cell_length(std::vector<std::vector<REAL>> cell_vertices, INT iv1, INT iv2, INT iv3, INT iv4){
+  const REAL Rlength2 = std::pow(0.5*(cell_vertices.at(iv1).at(0) + cell_vertices.at(iv2).at(0) -
+                 cell_vertices.at(iv3).at(0) - cell_vertices.at(iv4).at(0)),2.0);
+  const REAL Zlength2 = std::pow(0.5*(cell_vertices.at(iv1).at(1) + cell_vertices.at(iv2).at(1) -
+                 cell_vertices.at(iv3).at(1) - cell_vertices.at(iv4).at(1)),2.0);
+  REAL length = std::pow(Zlength2+Rlength2,0.5);
+  return length;
+}
+
+
 void check_cell_centres(std::shared_ptr<PetscInterface::DMPlexInterface>& neso_mesh,
-                        Mesh*& bout_mesh, BoutReal tolerance) {
+                        Mesh*& bout_mesh, BoutReal absolute_tolerance, BoutReal relative_tolerance) {
   Coordinates* coord = bout_mesh->getCoordinates();
   // get (R,Z) of cell centres in Hypnotoad grid
   Field2D Rxy;
@@ -694,16 +706,29 @@ void check_cell_centres(std::shared_ptr<PetscInterface::DMPlexInterface>& neso_m
       }
       neso_Rxy /= 4.0;
       neso_Zxy /= 4.0;
-
+      // get lengths of cell across the two dimensions
+      const REAL cell_length_a = cell_length(cell_vertices, 0, 1, 2, 3);
+      const REAL cell_length_b = cell_length(cell_vertices, 0, 3, 2, 1);
+      const REAL min_cell_length = std::min(cell_length_a, cell_length_b);
+      // we compare the difference in cell centres to the absolute tolerance and
+      // the relative tolerance formed by comparing to the smallest length across the cell
+      const REAL tolerance = absolute_tolerance + min_cell_length*relative_tolerance;
       const bool centres_match = (abs(neso_Rxy - bout_Rxy) < tolerance) &&
                                  (abs(neso_Zxy - bout_Zxy) < tolerance);
       // exit if we fail to find a match
       NESOASSERT(centres_match,
                  fmt::format("Hypnotoad/BOUT++ cell centre (R, Z) ({}, {}) does not match NESO-Particles mesh "
-                             "cell centre ({}, {}) for ix = {} iy = {} \n Ignore this message by "
+                             "cell centre ({}, {}) for ix = {} iy = {} \n"
+                             "The cell height and width are {} {} \n"
+                             "The displacements in R and Z are {} {} \n"
+                             "Ignore this message by "
                              "setting [neso_particles] test_cell_centres = false\n Relax the "
-                             "tolerance used in this check by increasing [neso_particles] cell_centre_tolerance = {}",
-                             bout_Rxy, bout_Zxy, neso_Rxy, neso_Zxy, ix, iy, tolerance));
+                             "tolerance used in this check by increasing\n"
+                             "[neso_particles] cell_centre_absolute_tolerance = {}\n"
+                             "[neso_particles] cell_centre_relative_tolerance = {}",
+                             bout_Rxy, bout_Zxy, neso_Rxy, neso_Zxy, ix, iy,
+                             cell_length_a, cell_length_b, abs(neso_Rxy - bout_Rxy), abs(neso_Zxy - bout_Zxy),
+                             absolute_tolerance, relative_tolerance));
       ixy++;
     }
   }
@@ -776,7 +801,9 @@ int main(int argc, char** argv) {
       check_cell_volumes(neso_mesh, bout_mesh);
     }
     if (Options::root()["neso_particles"]["test_cell_centres"].withDefault(true)){
-      check_cell_centres(neso_mesh,bout_mesh, Options::root()["neso_particles"]["cell_centre_tolerance"].withDefault(1.0e-12));
+      check_cell_centres(neso_mesh,bout_mesh,
+        Options::root()["neso_particles"]["cell_centre_absolute_tolerance"].withDefault(1.0e-12),
+        Options::root()["neso_particles"]["cell_centre_relative_tolerance"].withDefault(0.0));
     }
     // create a Reactions particle spec
     auto particle_spec_builder = ParticleSpecBuilder(ndim);

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -21,10 +21,12 @@ ny = 36  # Y grid size
 dx = 1.0/(nx-4)  # X mesh spacing
 dy = 2*pi/ny  # Y mesh spacing
 
+Rxy = x
 Rxy_corners = x - 0.5*dx
 Rxy_lower_right_corners = x + 0.5*dx
 Rxy_upper_left_corners = x - 0.5*dx
 Rxy_upper_right_corners = x + 0.5*dx
+Zxy = y
 Zxy_corners = y - 0.5*dy
 Zxy_lower_right_corners = y - 0.5*dy
 Zxy_upper_left_corners = y + 0.5*dy
@@ -39,6 +41,8 @@ dt = 0.005
 nsteps = 1
 test_mass_conservation = true
 test_cell_volumes = true
+test_cell_centres = true
+cell_centre_tolerance = 1e-12
 
 [VANTAGE_reactions]
 remove_threshold = 0.0e-10

--- a/examples/particle-push-slab/BOUT.inp
+++ b/examples/particle-push-slab/BOUT.inp
@@ -42,7 +42,11 @@ nsteps = 1
 test_mass_conservation = true
 test_cell_volumes = true
 test_cell_centres = true
-cell_centre_tolerance = 1e-12
+# tolerance to use when determining if the cell centre in the DMPlex matches the Hypnotoad grid
+cell_centre_absolute_tolerance = 1e-12
+# The relative tolerance is used to compare the displacement of the cell centre
+# to the smallest of the width and height of the DMPlex cell
+cell_centre_relative_tolerance = 1e-12
 
 [VANTAGE_reactions]
 remove_threshold = 0.0e-10

--- a/tests/integrated/particle-pusher/runtest
+++ b/tests/integrated/particle-pusher/runtest
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# Python script to run and analyse particle pushing test
+
+from boututils.run_wrapper import shell, launch_safe
+
+import h5py
+import numpy as np
+from petsc4py import PETSc
+import netCDF4 as nc
+
+# Link to the executable
+shell("ln -s ../../../bout-particle-push bout-particle-push")
+# make the run directory
+shell("mkdir particle-push-slab-test")
+
+# A function to define the BOUT.inp file contents
+def particle_push_input(nx=40, ny=36, dt=0.005, nsteps=1,
+      iz_rate=0.0, remove_threshold=0.0, merge_threshold=0.0):
+  input_file_string = f"""
+  # run a simulation with this file using
+  # $ OMP_NUM_THREADS=1 mpirun -np 8 ./bout-particle-push -d particle-push-slab
+  # postprocess with 
+  # $ python3 path/to/the/particle_animater.py hypnotoad_dmplex_mesh_output.h5 traj_reflection_dmplex_example.h5part
+  [mesh]
+  # Uses the full cxx implementation of DMPlex
+  # calculation to interface to NESO-Particles,
+  # removing need for python preprocessing.
+  # Needed for slab example to run.
+  use_cxx_ivertex=true
+
+  # if using a slab, uncomment and
+  # modify nx, ny, below
+  nx = {nx}  # X grid size
+  ny = {ny}  # Y grid size
+
+  dx = 1.0/({nx}-4)  # X mesh spacing
+  dy = 2*pi/{ny}  # Y mesh spacing
+
+  Rxy_corners = x - 0.5*dx
+  Rxy_lower_right_corners = x + 0.5*dx
+  Rxy_upper_left_corners = x - 0.5*dx
+  Rxy_upper_right_corners = x + 0.5*dx
+  Zxy_corners = y - 0.5*dy
+  Zxy_lower_right_corners = y - 0.5*dy
+  Zxy_upper_left_corners = y + 0.5*dy
+  Zxy_upper_right_corners = y + 0.5*dy
+
+  # initial_neutral_density can be a function of (x, y)
+  initial_neutral_density = 1.0
+
+  [neso_particles]
+  npart_per_cell = 1
+  dt = {dt}
+  nsteps = {nsteps}
+  test_mass_conservation = true
+  test_cell_volumes = true
+
+  [VANTAGE_reactions]
+  remove_threshold = {remove_threshold}
+  merge_threshold = {merge_threshold}
+  iz_rate = {iz_rate}
+  """
+  return input_file_string
+
+# function for reading resulting particle data
+def load_particle_data(file_path):
+  particle_data = h5py.File(file_path,"r")
+  data_all_timesteps = list(particle_data.keys())
+  nstep = len(data_all_timesteps)
+
+  particle_positions = []
+  for it in range(0,nstep):
+      try:
+          group = particle_data[f"Step#{it}"]
+          #print(list(group.keys()))
+          P_0 = group["POSITION_0"]
+          P_1 = group["POSITION_1"]
+          nparticles = len(P_0)
+          pdata = np.zeros((nparticles,2))
+          pdata[:,0] = P_0
+          pdata[:,1] = P_1
+          particle_positions.append(pdata)
+      except (KeyError) as error:
+          print(f"No particles at time step {it}: {error}")
+          # assign empty particle data
+          pdata = np.empty((0,2))
+          particle_positions.append(pdata)
+  return particle_positions
+
+def test_particle_push(file, nsteps = 10, remove_threshold = 0.0, merge_threshold = 0.0, iz_rate = 0.0):
+  with open(file,"w") as file:
+    file.write(particle_push_input(nx=40, ny=36, dt=0.005, nsteps=nsteps,
+        iz_rate=iz_rate, remove_threshold=remove_threshold, merge_threshold=remove_threshold))
+
+  # Command to run
+  cmd = "./bout-particle-push -d particle-push-slab-test"
+  nproc = 1
+  # Launch using MPI
+  s, out = launch_safe(cmd, nproc=nproc, mthread=1, pipe=True)
+  # variable to determine if test passed
+  success = True
+  particle_positions_file_path = "traj_reflection_dmplex_example.h5part"
+  particle_positions = load_particle_data(particle_positions_file_path)
+  nsteps_out = len(particle_positions)
+  # number of steps the same
+  success = success and (nsteps == nsteps_out)
+  # number of markers (or super particles) conserved
+  nparticles_0, _ = np.shape(particle_positions[0])
+  nparticles_N, _ = np.shape(particle_positions[-1])
+  success = success and (nparticles_0 == nparticles_N)
+  # check the mass diagnostic
+  ncfile_path = "bout_particle_moments_0.nc"
+  ncdataset = nc.Dataset(ncfile_path, mode='r')
+  total_mass = np.copy(ncdataset.variables["total_mass"][:])
+  total_ion_mass = np.copy(ncdataset.variables["total_ion_mass"][:])
+  total_neutral_mass = np.copy(ncdataset.variables["total_neutral_mass"][:])
+  # total mass should always be conserved
+  success = success and np.abs(total_mass[0] - total_mass[-1]) < 1.0e-11
+  # if we ionise particles there should be mass exchange between neutral and ion
+  if iz_rate > 0.0:
+    success = success and total_ion_mass[0] < total_ion_mass[-1]
+    success = success and total_neutral_mass[0] > total_neutral_mass[-1]
+  return success
+
+file = "particle-push-slab-test/BOUT.inp"
+success = True
+success = success and test_particle_push(file, nsteps = 10, remove_threshold = 1.0e-10, merge_threshold = 1.0e-6, iz_rate = 0.01)
+
+if success:
+  print(" => Test passed")
+  exit(0)
+else:
+  print(" => Test failed")
+  exit(1)

--- a/tests/integrated/particle-pusher/runtest
+++ b/tests/integrated/particle-pusher/runtest
@@ -58,7 +58,8 @@ def particle_push_input(nx=40, ny=36, dt=0.005, nsteps=1,
   test_mass_conservation = true
   test_cell_volumes = true
   test_cell_centres = true
-  cell_centre_tolerance = 1e-12
+  cell_centre_absolute_tolerance = 1e-12
+  cell_centre_relative_tolerance = 1e-12
 
   [VANTAGE_reactions]
   remove_threshold = {remove_threshold}

--- a/tests/integrated/particle-pusher/runtest
+++ b/tests/integrated/particle-pusher/runtest
@@ -37,10 +37,12 @@ def particle_push_input(nx=40, ny=36, dt=0.005, nsteps=1,
   dx = 1.0/({nx}-4)  # X mesh spacing
   dy = 2*pi/{ny}  # Y mesh spacing
 
+  Rxy = x
   Rxy_corners = x - 0.5*dx
   Rxy_lower_right_corners = x + 0.5*dx
   Rxy_upper_left_corners = x - 0.5*dx
   Rxy_upper_right_corners = x + 0.5*dx
+  Zxy = y
   Zxy_corners = y - 0.5*dy
   Zxy_lower_right_corners = y - 0.5*dy
   Zxy_upper_left_corners = y + 0.5*dy
@@ -55,6 +57,8 @@ def particle_push_input(nx=40, ny=36, dt=0.005, nsteps=1,
   nsteps = {nsteps}
   test_mass_conservation = true
   test_cell_volumes = true
+  test_cell_centres = true
+  cell_centre_tolerance = 1e-12
 
   [VANTAGE_reactions]
   remove_threshold = {remove_threshold}


### PR DESCRIPTION
A continuous integration test of `bout-particle-push` functionality in `tests/integrated/particle-pusher/runtest`.
The test includes
 - The native run-time tests within `bout-particle-push` (mass conservation, DMPlex vertex check).
 - A particle number check (the parameters are set so that the number of particle markers are conserved).
 - A mass check
 - A check that ionisation changes the neutral and ion masses in the correct direction.

To do in a future PR:
 - Run the test on the GitHub actions server. See https://github.com/UKAEA-Edge-Code/hermes-3/issues/14.