### PR TITLE
Use https rather than ssh to clone VANTAGE-Reactions.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 	url = https://github.com/boutproject/BOUT-spack.git
 [submodule "Reactions"]
 	path = external/Reactions
-	url = git@github.com:UKAEA-Edge-Code/VANTAGE-Reactions.git
+	url = https://github.com/UKAEA-Edge-Code/VANTAGE-Reactions.git


### PR DESCRIPTION
Use https rather than ssh to clone VANTAGE-Reactions. This supports the installation of hermes-3 in containers without ssh keys.