### PR TITLE
Do not compile NESO-Particles or VANTAGE-Reactions tests by default.

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -5,8 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - hermes-3+vantagereactions ^boutpp+petsc+sundials ^petsc+hypre+mumps ^py-numpy@1.26.4 ^vantage.vantagereactions+enable_tests
-    ^neso.neso-particles~nvcxx+petsc+build_tests ^openblas ^neso.adaptivecpp ^hdf5 %gcc
+  - hermes-3+vantagereactions ^boutpp+petsc+sundials ^petsc+hypre+mumps ^py-numpy@1.26.4 ^vantage.vantagereactions~enable_tests
+    ^neso.neso-particles~nvcxx+petsc~build_tests ^openblas ^neso.adaptivecpp ^hdf5 %gcc
   - cmake
   - py-meshio
   - py-petsc4py


### PR DESCRIPTION
Do not compile NESO-Particles or VANTAGE-Reactions tests by default. This saves compilation time and memory requirements. Users can easily reverse this change locally if the tests are required for mutual development of Hermes-3, NESO-Particles and VANTAGE-Reactions.