### PR TITLE
Use https rather than ssh to enable cloning within a Docker image.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,13 +13,13 @@
   url = https://github.com/UKAEA-Edge-Code/VANTAGE-Reactions.git
 [submodule "external/xhermes"]
 	path = external/xhermes
-	url = git@github.com:boutproject/xhermes
+	url = https://github.com/boutproject/xhermes.git
 	ignore = dirty
 [submodule "external/xbout"]
 	path = external/xbout
-	url = git@github.com:boutproject/xbout
+	url = https://github.com/boutproject/xBOUT.git
 	ignore = dirty
 [submodule "external/boutdata"]
 	path = external/boutdata
-	url = git@github.com:boutproject/boutdata.git
+	url = https://github.com/boutproject/boutdata.git
 	ignore = dirty


### PR DESCRIPTION
To clone without ssh access when creating a docker image requires that the submodules use https rather than ssh. Https is already the norm for the other submodules.