### PR TITLE
Move dependencies for python scripts used in CI testing of VANTAGE features 

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,8 +9,6 @@ spack:
     ^neso.neso-particles~nvcxx+petsc~build_tests ^openblas ^neso.adaptivecpp ^hdf5 %gcc
   - cmake
   - py-meshio
-  - py-petsc4py
-  - py-h5py
   - py-matplotlib+animation
   - py-pip
   - py-xbout


### PR DESCRIPTION
We need `py-h5py` and `py-petsc4py` for integrated testing of VANTAGE-Reactions and NESO-Particles features. See tests/integrated/particle-pusher/runtest. This PR moves those dependencies to the Hermes-3 package.py file.

In addition, this PR avoids `git submodule update` for spack installation, to enable spack installation in a docker container.